### PR TITLE
It seems to be a bug

### DIFF
--- a/src/main/java/com/github/to2mbn/jmccc/exec/DaemonStreamPumpMonitor.java
+++ b/src/main/java/com/github/to2mbn/jmccc/exec/DaemonStreamPumpMonitor.java
@@ -18,7 +18,7 @@ public class DaemonStreamPumpMonitor extends ProcessMonitor {
 
 		@Override
 		public void run() {
-			while (Thread.interrupted()) {
+			while (!Thread.interrupted()) {
 				try {
 					if (in.read() == -1) {
 						break;


### PR DESCRIPTION
The **StreamPump** class seems to be used to consume the buffer, but it didn't work.